### PR TITLE
handle reentrant close

### DIFF
--- a/node/quit.go
+++ b/node/quit.go
@@ -13,7 +13,12 @@ func (node *Node) Quit() {
 
 // stop the periodical tasks by closing the shutdown channel
 func (node *Node) Close() {
-	close(node.shutdownCh)
+	select {
+	case <-node.shutdownCh:
+		// channel already closed, do nothing
+	default:
+		close(node.shutdownCh)
+	}
 }
 
 // Notify the node's predecessor and successor it is leaving the ring.
@@ -33,6 +38,7 @@ func (node *Node) NotifySuccessorLeave() {
 	indexOfFirstLiveSuccessor, err := node.findFirstLiveSuccessor()
 	if err != nil {
 		node.Close()
+		return
 	}
 	_ = node.updateReplica(indexOfFirstLiveSuccessor)
 }

--- a/node/stabilize.go
+++ b/node/stabilize.go
@@ -12,6 +12,7 @@ func (node *Node) stabilize() {
 	indexOfFirstLiveSuccessor, err := node.findFirstLiveSuccessor()
 	if err != nil {
 		node.Close()
+		return
 	}
 	// update the successor list and backup files
 	_ = node.updateReplica(indexOfFirstLiveSuccessor)


### PR DESCRIPTION
This pull request includes changes to improve the stability and reliability of the node shutdown and stabilization processes. The most important changes involve ensuring proper handling of the shutdown channel and improving error handling in key functions.

Improvements to node shutdown:

* [`node/quit.go`](diffhunk://#diff-0f7f2f29b82dbcca3d06ac3e129b5af603cdafc914ef82275e661297288a098bR16-R22): Added a `select` statement in the `Close` method to check if the `shutdownCh` channel is already closed before attempting to close it again. This prevents potential panics due to closing a closed channel.

Error handling improvements:

* [`node/quit.go`](diffhunk://#diff-0f7f2f29b82dbcca3d06ac3e129b5af603cdafc914ef82275e661297288a098bR41): Added a `return` statement in the `NotifySuccessorLeave` method to ensure the function exits early if an error occurs while finding the first live successor.
* [`node/stabilize.go`](diffhunk://#diff-1c91e66e297f2e27b3a9082efed730191f639b67ed6f292fb37c065723aac61cR15): Added a `return` statement in the `stabilize` method to ensure the function exits early if an error occurs while finding the first live successor.