### PR TITLE
non twice

### DIFF
--- a/node/rpc.go
+++ b/node/rpc.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"crypto/tls"
+	"log"
 	"net"
 	"net/rpc"
 )
@@ -12,6 +13,15 @@ type RPCHandler int
 
 const RPCHandlerPrefix = "RPCHandler."
 
+// init registers the RPCHandler as an RPC server.
+// You shouldn't register the handler twice, otherwise, an error will be thrown.
+func init() {
+	handler := new(RPCHandler)
+	if err := rpc.Register(handler); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
 // startServer starts the rpc server for the node.
 // Use TLS if `node.tlsBool` is true, otherwise use normal TCP.
 // The RPCHandler will be:
@@ -21,11 +31,6 @@ const RPCHandlerPrefix = "RPCHandler."
 //
 // The server will be closed when the node's shutdown channel is closed.
 func (node *Node) startServer() error {
-	handler := new(RPCHandler)
-	if err := rpc.Register(handler); err != nil {
-		return err
-	}
-
 	var listener net.Listener = nil
 	var err error = nil
 	if node.tlsBool {


### PR DESCRIPTION
This pull request includes changes to the `node/rpc.go` file to improve the initialization and registration of the `RPCHandler`. The most important changes include adding a logging import and moving the handler registration to an `init` function.

Improvements to handler registration:

* [`node/rpc.go`](diffhunk://#diff-9e53bad15c0e122b71c450b79aaafd17bd140c7192a2055d741e3456eb33d776R5): Added the `log` package import to enable logging of errors.
* [`node/rpc.go`](diffhunk://#diff-9e53bad15c0e122b71c450b79aaafd17bd140c7192a2055d741e3456eb33d776R16-R24): Introduced an `init` function to register the `RPCHandler` as an RPC server, ensuring it is not registered twice.
* [`node/rpc.go`](diffhunk://#diff-9e53bad15c0e122b71c450b79aaafd17bd140c7192a2055d741e3456eb33d776L24-L28): Removed redundant `RPCHandler` registration from the `startServer` method, as it is now handled in the `init` function.